### PR TITLE
Serialize array params

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "jest": "^27.0.6",
     "jest-fetch-mock": "^3.0.3",
     "rollup": "^2.60.1"
+  },
+  "dependencies": {
+    "qs": "^6.10.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadolabs/auth-http-provider",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "HTTP Provider that works with JWT auth",
   "repository": "https://github.com/Cado-Labs/auth-http-provider",
   "homepage": "https://github.com/Cado-Labs/auth-http-provider",

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -1,3 +1,5 @@
+import qs from "qs"
+
 export default class Provider {
   constructor ({ factory, baseURL }) {
     this.factory = factory
@@ -87,10 +89,9 @@ export default class Provider {
 
   #buildUrl = (path, query = {}) => {
     const url = new URL(this.baseURL)
-    const searchParams = new URLSearchParams(query)
 
     url.pathname = path
-    url.search = searchParams.toString()
+    url.search = qs.stringify(query, { arrayFormat: "brackets" })
 
     return url.toString()
   }

--- a/tests/request.test.js
+++ b/tests/request.test.js
@@ -39,7 +39,7 @@ describe("making requests", () => {
       fetchMock.mockOnce(JSON.stringify({ success: true }), { status: 200 })
 
       const headers = { header: "value" }
-      const data = { key: "value" }
+      const data = { key: "value", arr: [1, 2] }
       const params = { headers }
 
       if (isGet) { params.query = data }
@@ -48,8 +48,11 @@ describe("making requests", () => {
       const fn = provider[method.toLowerCase()]
       const response = await fn("/route", params)
 
-      const expectedUrl = isGet ? "http://localhost/route?key=value" : "http://localhost/route"
-      const expectedBody = isGet ? null : JSON.stringify({ key: "value" })
+      const expectedUrl = isGet
+        ? "http://localhost/route?key=value&arr%5B%5D=1&arr%5B%5D=2"
+        : "http://localhost/route"
+
+      const expectedBody = isGet ? null : JSON.stringify({ key: "value", arr: [1, 2] })
 
       const expectedHeaders = { header: "value" }
       if (!isGet) { expectedHeaders["Content-Type"] = "application/json" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3864,6 +3864,13 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+qs@^6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.2.tgz#c1431bea37fc5b24c5bdbafa20f16bdf2a4b9ffe"
+  integrity sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"


### PR DESCRIPTION
Fixed array params serialization for GET requests so `{ arr: [1, 2] }` becomes `?arr[]=1&arr[]=2`