### PR TITLE
Update API to work with token pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ import AuthHTTPProvider from "@cadolabs/auth-http-provider"
 First you need to create a factory
 
 ```js
-const factory = AuthHTTPProvider.make({ getToken, saveToken, refreshToken, onError })
+const factory = AuthHTTPProvider.make({ getAccessToken, saveTokens, refreshTokens, onError })
 ```
 
 Options:
 
-- `getToken` – `void => Promise<string>` – returns saved auth token
-- `saveToken` – `token => Promise<void>` – save refreshed token
-- `refreshToken` – `() => Promise<string>` – refresh current token
+- `getAccessToken` – `() => Promise<string>` – returns saved access token
+- `saveTokens` – `(tokens: { accessToken: string, refreshToken: string }) => Promise<void>` – save tokens
+- `refreshTokens` – `() => Promise<{ accessToken: string, refreshToken: string }>` – refresh current tokens
 - `onError` – `Error => void` – calls on error (Error object is just a request from `fetch`)
 
 And after that you can create a http provider:
@@ -63,11 +63,11 @@ Request options:
 
 ## How does it work
 
-On each request performing it calls callback `getToken` to get the auth token and makes the request with auth header `Authorization: Bearer <token>`.
+On each request performing it calls callback `getAccessToken` to get the auth token and makes the request with auth header `Authorization: Bearer <token>`.
 
-When any request you made fails with 401 error code, it tries to refresh the token using callback `refreshToken` and perform it one more time with the new token. If it fails again, it calls `onError` callback and throws an error.
+When any request you made fails with 401 error code, it tries to refresh the tokens using callback `refreshTokens` and perform it one more time with the new access token. If it fails again, it calls `onError` callback and throws an error.
 
-If request complited successfully with new token, it calls `saveToken` to make your code save it somewhere.
+If request complited successfully with new token, it calls `saveTokens` to make your code save new tokens somewhere.
 
 In other cases it behaves like a regular request-performing library.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadolabs/auth-http-provider",
-  "version": "2.4.2",
+  "version": "3.0.0",
   "description": "HTTP Provider that works with JWT auth",
   "repository": "https://github.com/Cado-Labs/auth-http-provider",
   "homepage": "https://github.com/Cado-Labs/auth-http-provider",

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -45,18 +45,18 @@ export default class Provider {
   })
 
   #request = async request => {
-    const token = await this.factory.getToken()
+    const accessToken = await this.factory.getAccessToken()
 
-    const response = await this.#perform(request, token)
+    const response = await this.#perform(request, accessToken)
 
     if (response.ok) return response
 
     if (response.status === 401) {
-      const newToken = await this.factory.refreshToken()
-      const newResponse = await this.#perform(request, newToken)
+      const newTokens = await this.factory.refreshTokens()
+      const newResponse = await this.#perform(request, newTokens?.accessToken)
 
       if (newResponse.ok) {
-        await this.factory.saveToken(newToken)
+        await this.factory.saveTokens(newTokens)
         return newResponse
       }
 

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -53,7 +53,13 @@ export default class Provider {
 
     if (response.status === 401) {
       const newTokens = await this.factory.refreshTokens()
-      const newResponse = await this.#perform(request, newTokens?.accessToken)
+
+      if (!newTokens?.accessToken) {
+        this.factory.onError(response)
+        throw response
+      }
+
+      const newResponse = await this.#perform(request, newTokens.accessToken)
 
       if (newResponse.ok) {
         await this.factory.saveTokens(newTokens)

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,10 @@ class Factory {
     return new Factory(params)
   }
 
-  constructor ({ getToken, saveToken, refreshToken, onError }) {
-    this.getToken = getToken
-    this.saveToken = saveToken
-    this.refreshToken = refreshToken
+  constructor ({ getAccessToken, saveTokens, refreshTokens, onError }) {
+    this.getAccessToken = getAccessToken
+    this.saveTokens = saveTokens
+    this.refreshTokens = refreshTokens
     this.onError = onError
   }
 

--- a/tests/request.test.js
+++ b/tests/request.test.js
@@ -14,9 +14,9 @@ const refreshTokens = jest.fn(() => Promise.resolve({
 }))
 const onError = jest.fn(_error => Promise.resolve())
 
-const createProvider = () => {
+const createProvider = params => {
   return Provider
-    .make({ getAccessToken, saveTokens, refreshTokens, onError })
+    .make({ getAccessToken, saveTokens, refreshTokens, onError, ...params })
     .create({ baseURL: "http://localhost" })
 }
 
@@ -142,6 +142,28 @@ describe("errors", () => {
       expect(fetchMock).toHaveBeenCalledTimes(2)
       expect(fetchMock).toHaveBeenNthCalledWith(1, ...makeCallingMatcher("current-token"))
       expect(fetchMock).toHaveBeenNthCalledWith(2, ...makeCallingMatcher("new-access-token"))
+    })
+
+    it(`${method} | no re-request occurs if the token is not received`, async () => {
+      fetchMock.mockResponse("", { status: 401 })
+
+      const refreshTokensReturnedNothing = jest.fn(() => Promise.resolve())
+      const provider = createProvider({ refreshTokens: refreshTokensReturnedNothing })
+
+      try {
+        await provider.get("/route")
+      }
+      catch (e) {
+        expect(e.status).toEqual(401)
+      }
+
+      expect(getAccessToken).toHaveBeenCalled()
+      expect(refreshTokensReturnedNothing).toHaveBeenCalled()
+      expect(saveTokens).not.toHaveBeenCalled()
+      expect(onError).toHaveBeenCalled()
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(fetchMock).toHaveBeenNthCalledWith(1, ...makeCallingMatcher("current-token"))
     })
 
     it(`${method} | throws an error on non-401 statuses`, async () => {

--- a/tests/request.test.js
+++ b/tests/request.test.js
@@ -6,14 +6,17 @@ fetchMock.enableMocks()
 
 const METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
 
-const getToken = jest.fn(() => Promise.resolve("current-token"))
-const saveToken = jest.fn(_token => Promise.resolve())
-const refreshToken = jest.fn(() => Promise.resolve("new-token"))
+const getAccessToken = jest.fn(() => Promise.resolve("current-token"))
+const saveTokens = jest.fn(_tokens => Promise.resolve())
+const refreshTokens = jest.fn(() => Promise.resolve({
+  accessToken: "new-access-token",
+  refreshToken: "new-refresh-token",
+}))
 const onError = jest.fn(_error => Promise.resolve())
 
 const createProvider = () => {
   return Provider
-    .make({ getToken, saveToken, refreshToken, onError })
+    .make({ getAccessToken, saveTokens, refreshTokens, onError })
     .create({ baseURL: "http://localhost" })
 }
 
@@ -57,7 +60,7 @@ describe("making requests", () => {
 
       expect(response.status).toEqual(200)
       expect(response.json()).resolves.toEqual({ success: true })
-      expect(getToken).toHaveBeenCalled()
+      expect(getAccessToken).toHaveBeenCalled()
       expect(fetch).toHaveBeenCalledWith(expectedUrl, {
         method,
         body: expectedBody,
@@ -79,7 +82,7 @@ describe("making requests", () => {
 
       expect(response.status).toEqual(200)
       expect(response.json()).resolves.toEqual({ success: true })
-      expect(getToken).toHaveBeenCalled()
+      expect(getAccessToken).toHaveBeenCalled()
       expect(fetch).toHaveBeenCalledWith("http://localhost/route", {
         method,
         body: expect.any(FormData),
@@ -103,13 +106,16 @@ describe("refreshing token", () => {
 
       expect(response.status).toEqual(200)
       expect(response.json()).resolves.toEqual({ success: true })
-      expect(getToken).toHaveBeenCalled()
-      expect(saveToken).toHaveBeenCalledWith("new-token")
-      expect(refreshToken).toHaveBeenCalled()
+      expect(getAccessToken).toHaveBeenCalled()
+      expect(saveTokens).toHaveBeenCalledWith({
+        accessToken: "new-access-token",
+        refreshToken: "new-refresh-token",
+      })
+      expect(refreshTokens).toHaveBeenCalled()
 
       expect(fetchMock).toHaveBeenCalledTimes(2)
       expect(fetchMock).toHaveBeenNthCalledWith(1, ...makeCallingMatcher("current-token"))
-      expect(fetchMock).toHaveBeenNthCalledWith(2, ...makeCallingMatcher("new-token"))
+      expect(fetchMock).toHaveBeenNthCalledWith(2, ...makeCallingMatcher("new-access-token"))
     })
   })
 })
@@ -128,14 +134,14 @@ describe("errors", () => {
         expect(e.status).toEqual(401)
       }
 
-      expect(getToken).toHaveBeenCalled()
-      expect(refreshToken).toHaveBeenCalled()
-      expect(saveToken).not.toHaveBeenCalled()
+      expect(getAccessToken).toHaveBeenCalled()
+      expect(refreshTokens).toHaveBeenCalled()
+      expect(saveTokens).not.toHaveBeenCalled()
       expect(onError).toHaveBeenCalled()
 
       expect(fetchMock).toHaveBeenCalledTimes(2)
       expect(fetchMock).toHaveBeenNthCalledWith(1, ...makeCallingMatcher("current-token"))
-      expect(fetchMock).toHaveBeenNthCalledWith(2, ...makeCallingMatcher("new-token"))
+      expect(fetchMock).toHaveBeenNthCalledWith(2, ...makeCallingMatcher("new-access-token"))
     })
 
     it(`${method} | throws an error on non-401 statuses`, async () => {
@@ -150,9 +156,9 @@ describe("errors", () => {
         expect(e.status).toEqual(500)
       }
 
-      expect(getToken).toHaveBeenCalled()
-      expect(refreshToken).not.toHaveBeenCalled()
-      expect(saveToken).not.toHaveBeenCalled()
+      expect(getAccessToken).toHaveBeenCalled()
+      expect(refreshTokens).not.toHaveBeenCalled()
+      expect(saveTokens).not.toHaveBeenCalled()
       expect(onError).not.toHaveBeenCalled()
 
       expect(fetchMock).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
The api has been changed to work with a pair of tokens. 

Before:  
`getToken: () => Promise<string>`  
`saveToken: (token: string) => Promise<void>`  
`refreshToken: () => Promise<string>`  

After: 
`getAccessToken: () => Promise<string>`  
`saveTokens: (tokens: { accessToken: string, refreshToken: string }) => Promise<void>`  
`refreshTokens: () => Promise<{ accessToken: string, refreshToken: string }>`  

Problem with the old approach:
When a 401 error occurred, the HTTP wrapper saved only one of the tokens, which caused issues when working with a pair.


