### PR TITLE
Fix tokens bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadolabs/auth-http-provider",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "HTTP Provider that works with JWT auth",
   "repository": "https://github.com/Cado-Labs/auth-http-provider",
   "homepage": "https://github.com/Cado-Labs/auth-http-provider",

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -44,6 +44,21 @@ export default class Provider {
     headers,
   })
 
+  #refreshPromise = null
+
+  #refreshTokens = () => {
+    if (this.#refreshPromise) return this.#refreshPromise
+    this.#refreshPromise = this.factory.refreshTokens()
+      .then(async newTokens => {
+        if (newTokens?.accessToken) await this.factory.saveTokens(newTokens)
+        return newTokens
+      })
+      .finally(() => {
+        this.#refreshPromise = null
+      })
+    return this.#refreshPromise
+  }
+
   #request = async request => {
     const accessToken = await this.factory.getAccessToken()
 
@@ -52,7 +67,7 @@ export default class Provider {
     if (response.ok) return response
 
     if (response.status === 401) {
-      const newTokens = await this.factory.refreshTokens()
+      const newTokens = await this.#refreshTokens()
 
       if (!newTokens?.accessToken) {
         this.factory.onError(response)
@@ -62,7 +77,6 @@ export default class Provider {
       const newResponse = await this.#perform(request, newTokens.accessToken)
 
       if (newResponse.ok) {
-        await this.factory.saveTokens(newTokens)
         return newResponse
       }
 

--- a/tests/request.test.js
+++ b/tests/request.test.js
@@ -120,6 +120,61 @@ describe("refreshing token", () => {
   })
 })
 
+describe("saving tokens", () => {
+  METHODS.forEach(method => {
+    it(`${method} | saves tokens right after refresh, even if retry fails`, async () => {
+      fetchMock.mockResponse("", { status: 401 })
+
+      const localSaveTokens = jest.fn(() => Promise.resolve())
+      const provider = createProvider({ saveTokens: localSaveTokens })
+
+      try {
+        await provider[method.toLowerCase()]("/route")
+      }
+      catch (_e) {
+        // expected to throw
+      }
+
+      expect(refreshTokens).toHaveBeenCalled()
+      expect(localSaveTokens).toHaveBeenCalledWith({
+        accessToken: "new-access-token",
+        refreshToken: "new-refresh-token",
+      })
+    })
+  })
+})
+
+describe("concurrent token refresh", () => {
+  it("refreshes token only once when multiple requests get 401 simultaneously", async () => {
+    fetchMock.mockResponses(
+      ["", { status: 401 }],
+      ["", { status: 401 }],
+      [JSON.stringify({ success: true }), { status: 200 }],
+      [JSON.stringify({ success: true }), { status: 200 }],
+    )
+
+    const localRefreshTokens = jest.fn(() => Promise.resolve({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+    }))
+    const localSaveTokens = jest.fn(() => Promise.resolve())
+    const provider = createProvider({
+      refreshTokens: localRefreshTokens,
+      saveTokens: localSaveTokens,
+    })
+
+    const [response1, response2] = await Promise.all([
+      provider.get("/route"),
+      provider.get("/route"),
+    ])
+
+    expect(response1.status).toEqual(200)
+    expect(response2.status).toEqual(200)
+    expect(localRefreshTokens).toHaveBeenCalledTimes(1)
+    expect(localSaveTokens).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe("errors", () => {
   METHODS.forEach(method => {
     it(`${method} | calls onError when refresh token didn't help`, async () => {
@@ -136,7 +191,10 @@ describe("errors", () => {
 
       expect(getAccessToken).toHaveBeenCalled()
       expect(refreshTokens).toHaveBeenCalled()
-      expect(saveTokens).not.toHaveBeenCalled()
+      expect(saveTokens).toHaveBeenCalledWith({
+        accessToken: "new-access-token",
+        refreshToken: "new-refresh-token",
+      })
       expect(onError).toHaveBeenCalled()
 
       expect(fetchMock).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
- Added `#refreshPromise` mutex inside `Provider` for concurrent 401s.
- Moved `saveTokens` inside the mutex, right after `refreshTokens` resolves, before the retry. This guarantees tokens are persisted regardless of what happens next.